### PR TITLE
feat: add dashboard visualizations and navigation for departments and employees

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.0",
+    "@types/recharts": "^1.8.29",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -20,12 +21,14 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",
+    "recharts": "^2.13.3",
     "tailwind-merge": "^2.5.4",
     "tailwindcss": "^3.4.14",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
+    "@shadcn/ui": "^0.0.4",
     "@types/node": "^22.9.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -34,6 +37,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.11.0",
+    "shadcn-ui": "^0.9.3",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.11.0",
     "vite": "^5.4.10"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,12 @@
-import {BrowserRouter as Router, Routes, Route} from 'react-router-dom';
-import {useState, useEffect} from 'react';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import MainLayout from './layouts/MainLayout';
-import LoginPage from './components/LoginPage';
-import RegisterPage from './components/RegisterPage';
-
-const Home = () => (
-  <div>
-    <h1 className="text-2xl font-bold mb-4">Welcome to HR Management System</h1>
-    <p>Select an option from the menu to get started.</p>
-  </div>
-);
+import LoginPage from './pages/auth/LoginPage';
+import RegisterPage from './pages/auth/RegisterPage';
+import OrganizationPage from './pages/dashboard/OrganizationPage';
+import DepartmentPage from './pages/departments/DepartmentPage';
+import DepartmentDetailPage from './pages/departments/DepartmentsDetailPage';
+import EmployeesPage from './pages/employees/EmployeesPage';
 
 function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(
@@ -25,21 +22,22 @@ function App() {
       {isAuthenticated ? (
         <MainLayout isAuthenticated={isAuthenticated} setIsAuthenticated={setIsAuthenticated}>
           <Routes>
-            <Route path="/main" element={<Home/>}/>
-            {/* Add other protected routes here */}
+            <Route path="/" element={<OrganizationPage />} />
+            <Route path="/departments" element={<DepartmentPage />} />
+            <Route path="/departments/:id" element={<DepartmentDetailPage />} />
+            <Route path="/employees" element={<EmployeesPage />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </MainLayout>
       ) : (
-        <MainLayout isAuthenticated={isAuthenticated} setIsAuthenticated={setIsAuthenticated}>
-          <Routes>
-            <Route path="/" element={<LoginPage setIsAuthenticated={setIsAuthenticated}/>}/>
-            <Route path="/register" element={<RegisterPage/>}/>
-          </Routes>
-        </MainLayout>
+        <Routes>
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/login" element={<LoginPage setIsAuthenticated={setIsAuthenticated} />} />
+          <Route path="*" element={<Navigate to="/login" replace />} />
+        </Routes>
       )}
     </Router>
   );
 }
 
 export default App;
-

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-white text-gray-950 shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-gray-500", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,7 +1,6 @@
-// MainLayout.tsx
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { AlertCircle, Users, Building2, LayoutDashboard } from 'lucide-react';
+import { AlertCircle, Building2, LayoutDashboard, Users } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 
 interface MainLayoutProps {
@@ -11,7 +10,6 @@ interface MainLayoutProps {
 }
 
 const MainLayout: React.FC<MainLayoutProps> = ({ children, isAuthenticated, setIsAuthenticated }) => {
-  // handle logout
   const handleLogout = () => {
     setIsAuthenticated(false);
     localStorage.removeItem('isAuthenticated');
@@ -35,61 +33,43 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children, isAuthenticated, setI
         </div>
       </header>
 
-      {isAuthenticated ? (
-        <>
-          {/* Navigation */}
-          <nav className="bg-white shadow-sm">
-            <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-              <div className="flex space-x-8 h-16 items-center">
-                <Link
-                  to="/"
-                  className="flex items-center text-gray-700 hover:text-gray-900"
-                >
-                  <LayoutDashboard className="w-5 h-5 mr-2" />
-                  Dashboard
-                </Link>
-
-                <Link
-                  to="/departments"
-                  className="flex items-center text-gray-700 hover:text-gray-900"
-                >
-                  <Building2 className="w-5 h-5 mr-2" />
-                  Departments
-                </Link>
-
-                <Link
-                  to="/employees"
-                  className="flex items-center text-gray-700 hover:text-gray-900"
-                >
-                  <Users className="w-5 h-5 mr-2" />
-                  Employees
-                </Link>
-              </div>
-            </div>
-          </nav>
-
-          {/* Main Content */}
-          <main>
-            <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-              <div className="bg-white rounded-lg shadow p-6">
-                <div>
-                  <h1 className="text-2xl font-bold mb-4">Welcome to HR Management System</h1>
-                  <p>Select an option from the menu to get started.</p>
-                </div>
-              </div>
-            </div>
-          </main>
-        </>
-      ) : (
-        // Only display login or register content when not authenticated
-        <main>
-          <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-            <div className="bg-white rounded-lg shadow p-6">
-              {children}
-            </div>
+      {isAuthenticated && (
+        <nav className="bg-white shadow-sm">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex space-x-8 h-16 items-center">
+            <Link
+              to="/"
+              className="flex items-center text-gray-700 hover:text-gray-900"
+            >
+              <LayoutDashboard className="w-5 h-5 mr-2" />
+              Dashboard
+            </Link>
+      
+            <Link
+              to="/departments"
+              className="flex items-center text-gray-700 hover:text-gray-900"
+            >
+              <Building2 className="w-5 h-5 mr-2" />
+              Departments
+            </Link>
+      
+            <Link
+              to="/employees"
+              className="flex items-center text-gray-700 hover:text-gray-900"
+            >
+              <Users className="w-5 h-5 mr-2" />
+              Employees
+            </Link>
           </div>
-        </main>
+        </div>
+      </nav>
       )}
+
+      <main>
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          {children}
+        </div>
+      </main>
 
       {/* Error Alert Component */}
       <div className="fixed bottom-4 right-4">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-)
+);

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from "react-router-dom";
-import { ApiResponse, LoginResponse } from '../types/apiResponses';
-import ApiService from '../services/api';
+import { ApiResponse, LoginResponse } from '../../types/apiResponses';
+import ApiService from '../../services/api';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
 interface LoginPageProps {
@@ -24,6 +24,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ setIsAuthenticated }) => {
             const response: ApiResponse<LoginResponse> = await ApiService.login(uniqueId);
             if (response.status === 200 && response.data.status === 'success') {
                 setIsAuthenticated(true);
+                localStorage.setItem('clientId', uniqueId);
                 setMessage(response.data.message);
             } else {
                 setMessage('Login failed. Please check your ID and try again.');

--- a/src/pages/auth/RegisterPage.tsx
+++ b/src/pages/auth/RegisterPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from "react-router-dom";
-import ApiService from "../services/api";
+import ApiService from "../../services/api";
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
 const RegisterPage: React.FC = () => {

--- a/src/pages/dashboard/OrganizationPage.tsx
+++ b/src/pages/dashboard/OrganizationPage.tsx
@@ -1,0 +1,278 @@
+import React, { useState, useEffect } from 'react';
+import { Building2, DollarSign, TrendingUp, Users, AlertCircle } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import ApiService from "../../services/api";
+import { 
+  Department, 
+  Employee, 
+  DepartmentInfo, 
+  Organization 
+} from '../../types/apiResponses';
+import DepartmentStats from './OrganizationStats';
+
+
+interface Stats {
+  budget: any;
+  performance: any;
+  positions: any;
+}
+
+const DepartmentsPage = () => {
+  const [organization, setOrganization] = useState<Organization | null>(null);
+  const [departments, setDepartments] = useState<Department[]>([]);
+  const [selectedDept, setSelectedDept] = useState<number | null>(null);
+  const [selectedDeptInfo, setSelectedDeptInfo] = useState<DepartmentInfo | null>(null);
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const clientId = localStorage.getItem('clientId');
+
+  useEffect(() => {
+    fetchOrganizationInfo();
+  }, []);
+
+  const fetchOrganizationInfo = async () => {
+    if (!clientId) {
+      setError('No client ID found. Please login again.');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const response = await ApiService.getOrgInfo(clientId);
+      
+      if (response.status === 200) {
+        console.log('Organization data:', response.data);
+        setOrganization(response.data);
+        setDepartments(response.data.departments || []);
+        setError(null);
+      } else {
+        setError('Failed to fetch organization data');
+      }
+    } catch (err) {
+      console.error('Error fetching organization data:', err);
+      setError('Failed to connect to the server');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchDepartmentDetails = async (deptId: number) => {
+    if (!clientId) {
+      setError('No client ID found. Please login again.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      // Fetch department info
+      const deptInfoRes = await ApiService.getDepartmentInfo(clientId, deptId);
+      
+      if (deptInfoRes.status === 200) {
+        setSelectedDeptInfo(deptInfoRes.data);
+        setEmployees(deptInfoRes.data.employees || []);
+        setSelectedDept(deptId);
+
+        // Fetch department statistics
+        const [budgetStats, perfStats, posStats] = await Promise.all([
+          ApiService.getDepartmentBudgetStats(clientId, deptId),
+          ApiService.getDepartmentPerfStats(clientId, deptId),
+          ApiService.getDepartmentPosStats(clientId, deptId)
+        ]);
+
+        setStats({
+          budget: budgetStats.data,
+          performance: perfStats.data,
+          positions: posStats.data
+        });
+
+        setError(null);
+      } else {
+        setError('Failed to fetch department details');
+      }
+    } catch (err) {
+      console.error('Error fetching department details:', err);
+      setError('Failed to load department details');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-gray-500">Loading...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-7xl mx-auto">
+        {error && (
+          <Alert variant="destructive" className="mb-6">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">
+            {organization?.name || 'Loading...'}
+          </h1>
+          <p className="mt-2 text-gray-600">Department Management</p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
+          {/* Department List */}
+          <div className="lg:col-span-1">
+            <Card>
+              <CardHeader>
+                <CardTitle>Department List</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {departments.length === 0 ? (
+                  <div className="text-center py-4 text-gray-500">
+                    No departments found
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {departments.map((dept) => (
+                      <button
+                        key={dept.id}
+                        onClick={() => fetchDepartmentDetails(dept.id)}
+                        className={`w-full p-3 text-left rounded-lg transition-colors ${
+                          selectedDept === dept.id
+                            ? 'bg-blue-50 text-blue-700'
+                            : 'hover:bg-gray-50'
+                        }`}
+                      >
+                        <div className="flex items-center">
+                          <Building2 className="h-5 w-5 mr-3" />
+                          <div>
+                            <div className="font-medium">{dept.name}</div>
+                            <div className="text-sm text-gray-500">
+                              Head: {dept.head || 'Not assigned'}
+                            </div>
+                            <div className="text-sm text-gray-500">
+                              {dept.employeeCount} employees
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Department Details */}
+          <div className="lg:col-span-3">
+            {selectedDeptInfo ? (
+              <div className="space-y-6">
+                {/* Basic Info Card */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>{selectedDeptInfo.name}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                      <div>
+                        <p className="text-sm font-medium text-gray-500">Department Head</p>
+                        <p className="mt-1">{selectedDeptInfo.head || 'Not assigned'}</p>
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium text-gray-500">Total Employees</p>
+                        <p className="mt-1">{employees.length}</p>
+                      </div>
+                      {stats?.budget && (
+                        <div>
+                          <p className="text-sm font-medium text-gray-500">Total Budget</p>
+                          <p className="mt-1">${stats.budget.total?.toLocaleString()}</p>
+                        </div>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+
+
+                      
+                {/* Department Stats */}
+                {clientId && selectedDept && (
+                  <DepartmentStats 
+                    clientId={clientId}
+                    departmentId={selectedDept}
+                  />
+                )}
+
+                {/* Employee Table */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Department Employees</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="relative overflow-x-auto">
+                      <table className="w-full text-sm text-left">
+                        <thead>
+                          <tr className="bg-gray-50">
+                            <th className="px-4 py-2">Name</th>
+                            <th className="px-4 py-2">Position</th>
+                            <th className="px-4 py-2 text-right">Performance</th>
+                            <th className="px-4 py-2 text-right">Salary</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y">
+                          {employees.length === 0 ? (
+                            <tr>
+                              <td colSpan={4} className="px-4 py-4 text-center text-gray-500">
+                                No employees found in this department
+                              </td>
+                            </tr>
+                          ) : (
+                            employees.map((employee) => (
+                              <tr key={employee.id} className="hover:bg-gray-50">
+                                <td className="px-4 py-2">{employee.name}</td>
+                                <td className="px-4 py-2 text-gray-500">
+                                  {employee.position}
+                                </td>
+                                <td className="px-4 py-2 text-right">
+                                  {employee.performance.toFixed(1)}
+                                </td>
+                                <td className="px-4 py-2 text-right">
+                                  ${employee.salary.toLocaleString()}
+                                </td>
+                              </tr>
+                            ))
+                          )}
+                        </tbody>
+                      </table>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-64 bg-white rounded-lg border-2 border-dashed">
+                <div className="text-center">
+                  <Building2 className="mx-auto h-12 w-12 text-gray-400" />
+                  <h3 className="mt-2 text-sm font-medium text-gray-900">
+                    No department selected
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Select a department from the list to view details
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DepartmentsPage;

--- a/src/pages/dashboard/OrganizationStats.tsx
+++ b/src/pages/dashboard/OrganizationStats.tsx
@@ -1,0 +1,209 @@
+import React, { useState, useEffect } from 'react';
+import { 
+  BarChart, Bar, LineChart, Line, PieChart, Pie, 
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend, Cell,
+  ResponsiveContainer 
+} from 'recharts';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import ApiService from "../../services/api";
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface DepartmentStatsProps {
+  clientId: string;
+  departmentId: number;
+}
+
+const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884d8'];
+
+const DepartmentStats: React.FC<DepartmentStatsProps> = ({ clientId, departmentId }) => {
+  const [budgetStats, setBudgetStats] = useState<any>(null);
+  const [perfStats, setPerfStats] = useState<any>(null);
+  const [posStats, setPosStats] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      console.log('Fetching stats for department:', departmentId);
+      try {
+        const [budgetRes, perfRes, posRes] = await Promise.all([
+          ApiService.getDepartmentBudgetStats(clientId, departmentId),
+          ApiService.getDepartmentPerfStats(clientId, departmentId),
+          ApiService.getDepartmentPosStats(clientId, departmentId)
+        ]);
+
+        console.log('Budget stats:', budgetRes.data);
+        console.log('Performance stats:', perfRes.data);
+        console.log('Position stats:', posRes.data);
+
+        setBudgetStats(budgetRes.data);
+        console.log('Budget stats:', budgetStats);
+        setPerfStats(perfRes.data);
+        console.log('Performance stats:', perfStats);
+        setPosStats(posRes.data);
+        console.log('Position stats:', posStats);
+      } catch (err) {
+        console.error('Error fetching stats:', err);
+        setError('Failed to load department statistics');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (clientId && departmentId) {
+      fetchStats();
+    }
+  }, [clientId, departmentId]);
+
+  if (loading) {
+    return <div className="text-center py-4">Loading statistics...</div>;
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!budgetStats || !perfStats || !posStats) {
+    return <div className="text-center py-4">No statistics available</div>;
+  }
+
+ // Transform position statistics for pie chart
+ const positionData = Object.entries(posStats).map(([name, value]) => ({
+  name: name.charAt(0).toUpperCase() + name.slice(1), // Capitalize first letter
+  value: Number(value) || 0
+})).filter(item => item.value > 0);
+
+// Transform performance data for line chart
+const performanceData = [
+  { name: "Lowest", value: perfStats.lowest || 0 },
+  { name: "25th", value: perfStats.percentile25 || 0 },
+  { name: "Median", value: perfStats.median || 0 },
+  { name: "75th", value: perfStats.percentile75 || 0 },
+  { name: "Highest", value: perfStats.highest || 0 }
+].filter(item => item.value !== 0);
+
+// Transform salary data for bar chart
+const salaryData = [
+  { name: "Average", value: Number(budgetStats.average) || 0 },
+  { name: "Lowest", value: Number(budgetStats.lowest) || 0 },
+  { name: "Highest", value: Number(budgetStats.highest) || 0 }
+].filter(item => item.value > 0);
+
+return (
+  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    {/* Position Distribution Chart */}
+    <Card>
+  <CardHeader>
+    <CardTitle>Position Distribution</CardTitle>
+  </CardHeader>
+  <CardContent>
+    <div className="h-[300px]">
+      {positionData.length > 0 ? (
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={positionData}
+              cx="50%"
+              cy="50%"
+              labelLine={false}
+              label={false}  // 移除标签
+              outerRadius={100}
+              fill="#8884d8"
+              dataKey="value"
+            >
+              {positionData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip 
+              formatter={(value, name, entry) => {
+                const total = positionData.reduce((sum, item) => sum + item.value, 0);
+                const percent = ((value as number) / total * 100).toFixed(1);
+                return [`${value} (${percent}%)`, name];
+              }}
+            />
+            <Legend
+              layout="vertical"
+              align="right"
+              verticalAlign="middle"
+              formatter={(value) => (
+                <span className="text-sm">{value}</span>
+              )}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex items-center justify-center h-full text-gray-500">
+          No position data available
+        </div>
+      )}
+    </div>
+  </CardContent>
+</Card>
+
+    {/* Performance Distribution Chart */}
+    {performanceData.some(item => item.value > 0) && (
+      <Card>
+        <CardHeader>
+          <CardTitle>Performance Distribution</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-[300px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={performanceData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis domain={[0, 5]} />
+                <Tooltip />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey="value"
+                  stroke="#8884d8"
+                  activeDot={{ r: 8 }}
+                  name="Performance Score"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </CardContent>
+      </Card>
+    )}
+
+    {/* Department Overview */}
+    <Card className="md:col-span-2">
+      <CardHeader>
+        <CardTitle>Department Overview</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <div>
+            <h3 className="text-sm font-medium text-gray-500">Total Budget</h3>
+            <p className="mt-1 text-2xl font-semibold">
+              ${budgetStats.total?.toLocaleString()}
+            </p>
+          </div>
+          <div>
+            <h3 className="text-sm font-medium text-gray-500">Average Salary</h3>
+            <p className="mt-1 text-2xl font-semibold">
+              ${budgetStats.average?.toLocaleString()}
+            </p>
+          </div>
+          <div>
+            <h3 className="text-sm font-medium text-gray-500">Average Performance</h3>
+            <p className="mt-1 text-2xl font-semibold">
+              {perfStats.average?.toFixed(2)}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+);
+};
+
+export default DepartmentStats;

--- a/src/pages/departments/DepartmentPage.tsx
+++ b/src/pages/departments/DepartmentPage.tsx
@@ -1,0 +1,112 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Building2, Users, DollarSign, ChevronRight } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import ApiService from '../../services/api';
+import type { Department } from '../../types/apiResponses';
+
+const DepartmentsPage = () => {
+  const navigate = useNavigate();
+  const [departments, setDepartments] = useState<Department[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchDepartments = async () => {
+      const clientId = localStorage.getItem('clientId');
+      if (!clientId) {
+        setError('No client ID found');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const response = await ApiService.getOrgInfo(clientId);
+        if (response.status === 200) {
+          setDepartments(response.data.departments || []);
+        } else {
+          setError('Failed to fetch departments');
+        }
+      } catch (err) {
+        setError('Error connecting to server');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDepartments();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen">
+        <p className="text-gray-500">Loading departments...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-6">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-bold">Departments</h1>
+        <button className="bg-black text-white px-4 py-2 rounded-md hover:bg-gray-800 transition-colors">
+          Add Department
+        </button>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {departments.map((dept) => (
+          <Card 
+            key={dept.id}
+            className="hover:shadow-lg transition-shadow cursor-pointer"
+            onClick={() => navigate(`/departments/${dept.id}`)}
+          >
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-xl font-bold">{dept.name}</CardTitle>
+              <Building2 className="h-5 w-5 text-gray-500" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-2">
+                    <Users className="h-4 w-4 text-gray-500" />
+                    <span className="text-sm text-gray-500">Employees</span>
+                  </div>
+                  <span className="font-medium">{dept.employeeCount}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-2">
+                    <DollarSign className="h-4 w-4 text-gray-500" />
+                    <span className="text-sm text-gray-500">Department Head</span>
+                  </div>
+                  <span className="font-medium">{dept.head || 'Not assigned'}</span>
+                </div>
+                <div className="flex items-center justify-end text-sm text-blue-600">
+                  View Details 
+                  <ChevronRight className="h-4 w-4 ml-1" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {departments.length === 0 && !error && (
+        <div className="text-center py-12">
+          <Building2 className="h-12 w-12 mx-auto text-gray-400" />
+          <h3 className="mt-2 text-lg font-medium text-gray-900">No departments</h3>
+          <p className="mt-1 text-gray-500">Get started by creating a new department.</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DepartmentsPage;

--- a/src/pages/departments/DepartmentsDetailPage.tsx
+++ b/src/pages/departments/DepartmentsDetailPage.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Building2, ArrowLeft, Users } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import ApiService from '../../services/api';
+import type { DepartmentInfo, Employee } from '../../types/apiResponses';
+
+const DepartmentDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const [departmentInfo, setDepartmentInfo] = useState<DepartmentInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchDepartmentDetails = async () => {
+      const clientId = localStorage.getItem('clientId');
+      if (!clientId || !id) {
+        setError('Invalid department ID or client ID');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const response = await ApiService.getDepartmentInfo(clientId, parseInt(id));
+        if (response.status === 200) {
+          setDepartmentInfo(response.data);
+        } else {
+          setError('Failed to fetch department details');
+        }
+      } catch (err) {
+        setError('Error connecting to server');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDepartmentDetails();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen">
+        <p className="text-gray-500">Loading department details...</p>
+      </div>
+    );
+  }
+
+  if (error || !departmentInfo) {
+    return (
+      <Alert variant="destructive" className="m-6">
+        <AlertDescription>{error || 'Department not found'}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-6">
+      <div className="mb-6">
+        <Link 
+          to="/departments"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back to Departments
+        </Link>
+      </div>
+
+      <div className="flex justify-between items-center mb-6">
+        <div className="flex items-center space-x-4">
+          <Building2 className="h-8 w-8 text-gray-700" />
+          <div>
+            <h1 className="text-3xl font-bold">{departmentInfo.name}</h1>
+            <p className="text-gray-500">Department Head: {departmentInfo.head || 'Not assigned'}</p>
+          </div>
+        </div>
+        <button className="bg-black text-white px-4 py-2 rounded-md hover:bg-gray-800 transition-colors">
+          Edit Department
+        </button>
+      </div>
+
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle className="flex items-center space-x-2">
+            <Users className="h-5 w-5" />
+            <span>Employees</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-left py-3 px-4">Name</th>
+                  <th className="text-left py-3 px-4">Position</th>
+                  <th className="text-right py-3 px-4">Performance</th>
+                  <th className="text-right py-3 px-4">Salary</th>
+                </tr>
+              </thead>
+              <tbody>
+                {departmentInfo.employees.map((employee) => (
+                  <tr key={employee.id} className="border-b hover:bg-gray-50">
+                    <td className="py-3 px-4">{employee.name}</td>
+                    <td className="py-3 px-4 text-gray-600">{employee.position}</td>
+                    <td className="py-3 px-4 text-right">{employee.performance.toFixed(1)}</td>
+                    <td className="py-3 px-4 text-right">${employee.salary.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default DepartmentDetailPage;

--- a/src/pages/employees/EmployeesPage.tsx
+++ b/src/pages/employees/EmployeesPage.tsx
@@ -1,0 +1,277 @@
+import React, { useState, useEffect } from 'react';
+import { Users, Search, Plus, Filter, ArrowUpDown } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import ApiService from '../../services/api';
+import type { Employee, Department } from '../../types/apiResponses';
+
+const EmployeesPage = () => {
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [departments, setDepartments] = useState<Department[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterDepartment, setFilterDepartment] = useState<string>('all');
+  const [sortConfig, setSortConfig] = useState<{
+    key: keyof Employee;
+    direction: 'asc' | 'desc';
+  } | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const clientId = localStorage.getItem('clientId');
+      if (!clientId) {
+        setError('No client ID found');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        // First get organization info to get departments
+        const orgResponse = await ApiService.getOrgInfo(clientId);
+        if (orgResponse.status === 200) {
+          setDepartments(orgResponse.data.departments);
+          
+          // Get detailed info for each department
+          const departmentDetailsPromises = orgResponse.data.departments.map(dept => 
+            ApiService.getDepartmentInfo(clientId, dept.id)
+          );
+
+          const deptResponses = await Promise.all(departmentDetailsPromises);
+          
+          // Combine all employees from all departments
+          const allEmployees = deptResponses.reduce((acc, response, index) => {
+            if (response.status === 200) {
+              const deptName = orgResponse.data.departments[index].name;
+              const deptEmployees = response.data.employees.map(emp => ({
+                ...emp,
+                department: deptName
+              }));
+              return [...acc, ...deptEmployees];
+            }
+            return acc;
+          }, [] as Employee[]);
+
+          setEmployees(allEmployees);
+        } else {
+          setError('Failed to fetch organization data');
+        }
+      } catch (err) {
+        console.error('Error fetching data:', err);
+        setError('Error connecting to server');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  // Handle sorting
+  const handleSort = (key: keyof Employee) => {
+    let direction: 'asc' | 'desc' = 'asc';
+    if (sortConfig?.key === key && sortConfig.direction === 'asc') {
+      direction = 'desc';
+    }
+    setSortConfig({ key, direction });
+  };
+
+  const sortEmployees = (employeeList: Employee[]) => {
+    if (!sortConfig) return employeeList;
+  
+    return [...employeeList].sort((a, b) => {
+      const aValue = a[sortConfig.key];
+      const bValue = b[sortConfig.key];
+  
+      // Handle undefined or null values
+      if (aValue === undefined && bValue === undefined) return 0;
+      if (aValue === undefined) return 1;  // undefined values go last
+      if (bValue === undefined) return -1;
+  
+      // Convert to strings for comparison if they're strings or numbers
+      const aString = aValue.toString().toLowerCase();
+      const bString = bValue.toString().toLowerCase();
+  
+      if (aString < bString) {
+        return sortConfig.direction === 'asc' ? -1 : 1;
+      }
+      if (aString > bString) {
+        return sortConfig.direction === 'asc' ? 1 : -1;
+      }
+      return 0;
+    });
+  };
+
+  // Filter employees
+  const filteredEmployees = employees.filter(employee => 
+    (filterDepartment === 'all' || employee.department === filterDepartment) &&
+    (employee.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+     employee.position.toLowerCase().includes(searchTerm.toLowerCase()) ||
+     employee.department?.toLowerCase().includes(searchTerm.toLowerCase()))
+  );
+
+  const sortedEmployees = sortEmployees(filteredEmployees);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen">
+        <p className="text-gray-500">Loading employees...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-6">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-bold">Employees</h1>
+        <button className="bg-black text-white px-4 py-2 rounded-md hover:bg-gray-800 transition-colors inline-flex items-center">
+          <Plus className="h-5 w-5 mr-2" />
+          Add Employee
+        </button>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader className="border-b">
+          <div className="flex flex-col md:flex-row justify-between items-start md:items-center space-y-4 md:space-y-0">
+            <CardTitle className="flex items-center space-x-2">
+              <Users className="h-5 w-5" />
+              <span>All Employees ({sortedEmployees.length})</span>
+            </CardTitle>
+            <div className="flex flex-col md:flex-row space-y-2 md:space-y-0 md:space-x-4 w-full md:w-auto">
+              <div className="relative">
+                <Filter className="h-4 w-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+                <select
+                  className="pl-10 pr-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  value={filterDepartment}
+                  onChange={(e) => setFilterDepartment(e.target.value)}
+                >
+                  <option value="all">All Departments</option>
+                  {departments.map(dept => (
+                    <option key={dept.id} value={dept.name}>
+                      {dept.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="relative">
+                <Search className="h-4 w-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+                <input
+                  type="text"
+                  placeholder="Search employees..."
+                  className="pl-10 pr-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 w-full"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b">
+                  <th 
+                    className="text-left py-3 px-4 cursor-pointer hover:bg-gray-50"
+                    onClick={() => handleSort('name')}
+                  >
+                    <div className="flex items-center space-x-2">
+                      <span>Name</span>
+                      <ArrowUpDown className="h-4 w-4" />
+                    </div>
+                  </th>
+                  <th 
+                    className="text-left py-3 px-4 cursor-pointer hover:bg-gray-50"
+                    onClick={() => handleSort('position')}
+                  >
+                    <div className="flex items-center space-x-2">
+                      <span>Position</span>
+                      <ArrowUpDown className="h-4 w-4" />
+                    </div>
+                  </th>
+                  <th 
+                    className="text-left py-3 px-4"
+                  >
+                    <div className="flex items-center space-x-2">
+                      <span>Department</span>
+                    </div>
+                  </th>
+                  <th 
+                    className="text-right py-3 px-4 cursor-pointer hover:bg-gray-50"
+                    onClick={() => handleSort('performance')}
+                  >
+                    <div className="flex items-center justify-end space-x-2">
+                      <span>Performance</span>
+                      <ArrowUpDown className="h-4 w-4" />
+                    </div>
+                  </th>
+                  <th 
+                    className="text-right py-3 px-4 cursor-pointer hover:bg-gray-50"
+                    onClick={() => handleSort('salary')}
+                  >
+                    <div className="flex items-center justify-end space-x-2">
+                      <span>Salary</span>
+                      <ArrowUpDown className="h-4 w-4" />
+                    </div>
+                  </th>
+                  <th className="text-right py-3 px-4">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedEmployees.map((employee) => (
+                  <tr key={employee.id} className="border-b hover:bg-gray-50">
+                    <td className="py-3 px-4">{employee.name}</td>
+                    <td className="py-3 px-4 text-gray-600">{employee.position}</td>
+                    <td className="py-3 px-4 text-gray-600">{employee.department}</td>
+                    <td className="py-3 px-4 text-right">
+                      <span className={`px-2 py-1 rounded-full text-sm ${
+                        employee.performance >= 4 ? 'bg-green-100 text-green-800' :
+                        employee.performance >= 3 ? 'bg-blue-100 text-blue-800' :
+                        'bg-yellow-100 text-yellow-800'
+                      }`}>
+                        {employee.performance.toFixed(1)}
+                      </span>
+                    </td>
+                    <td className="py-3 px-4 text-right">${employee.salary.toLocaleString()}</td>
+                    <td className="py-3 px-4 text-right">
+                      <div className="flex justify-end space-x-2">
+                        <button className="text-blue-600 hover:text-blue-800">
+                          Edit
+                        </button>
+                        <button className="text-red-600 hover:text-red-800">
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {sortedEmployees.length === 0 && (
+              <div className="text-center py-12">
+                <Users className="h-12 w-12 mx-auto text-gray-400" />
+                <h3 className="mt-2 text-lg font-medium text-gray-900">
+                  No employees found
+                </h3>
+                <p className="mt-1 text-gray-500">
+                  {searchTerm 
+                    ? 'Try adjusting your search or filter to find what you\'re looking for.'
+                    : 'Get started by adding a new employee.'}
+                </p>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default EmployeesPage;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,15 @@
-import { ApiResponse, LoginResponse, RegisterResponse } from '../types/apiResponses';
-
 const API_BASE_URL = 'http://localhost:8080';
+import { 
+  ApiResponse, 
+  LoginResponse, 
+  RegisterResponse,
+  Organization,
+  DepartmentInfo,
+  DepartmentBudgetStats,
+  DepartmentPerfStats,
+  DepartmentPosStats,
+  BasicResponse
+} from '../types/apiResponses';
 
 class ApiService {
   private static async request<T>(
@@ -10,8 +19,6 @@ class ApiService {
   ): Promise<ApiResponse<T>> {
     const url = new URL(`${API_BASE_URL}${endpoint}`);
     
-    // Add query parameters for all request
-    // TODO: should we add for all request?
     if (params) {
       Object.keys(params).forEach(key => 
         url.searchParams.append(key, String(params[key]))
@@ -23,108 +30,53 @@ class ApiService {
       headers: {
         'Content-Type': 'application/json',
       },
-      // Add body for non-GET requests
       ...(method !== 'GET' && params ? { body: JSON.stringify(params) } : {})
     });
-    // console.log(response);
+
     const data = await response.json();
     return { data, status: response.status };
   }
 
-  // Login
-  static async login(clientId: string) {
+  // Auth endpoints
+  static async login(clientId: string): Promise<ApiResponse<LoginResponse>> {
     return this.request<LoginResponse>('/login', 'POST', { cid: clientId });
   }
 
-  // Register
-  static async registerOrganization(name: string) {
+  static async registerOrganization(name: string): Promise<ApiResponse<RegisterResponse>> {
     return this.request<RegisterResponse>('/register', 'POST', { name });
   }
 
-  // Organization
-  static async getOrgInfo(clientId: string) {
-    return this.request('/getOrgInfo', 'GET', { cid: clientId });
+static async getOrgInfo(clientId: string): Promise<ApiResponse<Organization>> {
+  return this.request<Organization>('/getOrgInfo', 'GET', { cid: clientId });
+}
+
+  // Department endpoints
+  static async getDepartmentInfo(clientId: string, departmentId: number): Promise<ApiResponse<DepartmentInfo>> {
+    return this.request<DepartmentInfo>('/getDeptInfo', 'GET', { cid: clientId, did: departmentId });
   }
 
-  // Department
-  static async getDepartmentInfo(clientId: number, departmentId: number) {
-    return this.request('/getDeptInfo', 'GET', { cid: clientId, did: departmentId });
-  }
-
-  static async getDepartmentBudgetStats(clientId: number, departmentId: number) {
-    return this.request('/statDeptBudget', 'GET', { cid: clientId, did: departmentId });
-  }
-
-  static async getDepartmentPerfStats(clientId: number, departmentId: number) {
-    return this.request('/statDeptPerf', 'GET', { cid: clientId, did: departmentId });
-  }
-
-  static async getDepartmentPosStats(clientId: number, departmentId: number) {
-    return this.request('/statDeptPos', 'GET', { cid: clientId, did: departmentId });
-  }
-
-  static async setDepartmentHead(clientId: number, departmentId: number, employeeId: number) {
-    return this.request('/setDeptHead', 'PATCH', { 
+  static async getDepartmentBudgetStats(clientId: string, departmentId: number): Promise<ApiResponse<DepartmentBudgetStats>> {
+    return this.request<DepartmentBudgetStats>('/statDeptBudget', 'GET', { 
       cid: clientId, 
-      did: departmentId, 
-      eid: employeeId 
+      did: departmentId.toString() 
     });
   }
 
-  // Employee
-  static async getEmployeeInfo(clientId: number, employeeId: number) {
-    return this.request('/getEmpInfo', 'GET', { cid: clientId, eid: employeeId });
-  }
-
-  static async setEmployeePerformance(clientId: number, employeeId: number, performance: number) {
-    return this.request('/setEmpPerf', 'PATCH', {
-      cid: clientId,
-      eid: employeeId,
-      performance
+  static async getDepartmentPerfStats(clientId: string, departmentId: number): Promise<ApiResponse<DepartmentPerfStats>> {
+    return this.request<DepartmentPerfStats>('/statDeptPerf', 'GET', { 
+      cid: clientId, 
+      did: departmentId.toString() 
     });
   }
 
-  static async setEmployeePosition(clientId: number, employeeId: number, position: string) {
-    return this.request('/setEmpPos', 'PATCH', {
-      cid: clientId,
-      eid: employeeId,
-      position
+  static async getDepartmentPosStats(clientId: string, departmentId: number): Promise<ApiResponse<DepartmentPosStats>> {
+    return this.request<DepartmentPosStats>('/statDeptPos', 'GET', { 
+      cid: clientId, 
+      did: departmentId.toString() 
     });
   }
 
-  static async setEmployeeSalary(clientId: number, employeeId: number, salary: number) {
-    return this.request('/setEmpSalary', 'PATCH', {
-      cid: clientId,
-      eid: employeeId,
-      salary
-    });
-  }
 
-  static async addEmployeeToDepartment(
-    clientId: number, 
-    departmentId: number, 
-    name: string, 
-    hireDate: string
-  ) {
-    return this.request('/addEmpToDept', 'POST', {
-      cid: clientId,
-      did: departmentId,
-      name,
-      hireDate
-    });
-  }
-
-  static async removeEmployeeFromDepartment(
-    clientId: number,
-    departmentId: number,
-    employeeId: number
-  ) {
-    return this.request('/removeEmpFromDept', 'DELETE', {
-      cid: clientId,
-      did: departmentId,
-      eid: employeeId
-    });
-  }
 }
 
 export default ApiService;

--- a/src/types/apiResponses.ts
+++ b/src/types/apiResponses.ts
@@ -1,5 +1,4 @@
-// file for response data structs
-// we will need to add all response types here.
+// types/apiResponses.ts
 
 export interface ApiResponse<T> {
   data: T;
@@ -7,12 +6,86 @@ export interface ApiResponse<T> {
 }
 
 export interface LoginResponse {
-  status: string;  // success/failed
-  message: string; // message
+  status: string;
+  message: string;
 }
 
 export interface RegisterResponse {
   status: string;
   message: string;
   token: string;
+}
+
+export interface Employee {
+  id: number;
+  name: string;
+  position: string;
+  performance: number;
+  salary: number;
+  department?: string; 
+}
+
+export interface Department {
+  id: number;
+  name: string;
+  head: string;
+  employeeCount: number;
+  employees?: Employee[]; 
+}
+
+export interface Organization {
+  id: number;
+  name: string;
+  departments: Department[];
+  departments_id: number[];
+}
+
+export interface DepartmentInfo {
+  name: string;
+  head: string;
+  employees: Employee[];
+}
+
+export interface DepartmentBudgetStats {
+  total: number;
+  average: number;
+  highest: number;
+  lowest: number;
+  highestEmployee: number | null;
+  lowestEmployee: number | null;
+}
+
+export interface DepartmentPerfStats {
+  highest: number;
+  percentile25: number;
+  median: number;
+  percentile75: number;
+  lowest: number;
+  average: number;
+  sortedEmployeeIds: number[];
+}
+
+export interface DepartmentPosStats {
+  [key: string]: number;
+}
+
+export interface EmployeeInfo {
+  id: number;
+  name: string;
+  department: string;
+  position: string;
+  salary: number;
+  performance: number;
+  hireDate: string;
+}
+
+export interface DepartmentStats {
+  budgetStats: DepartmentBudgetStats;
+  perfStats: DepartmentPerfStats;
+  posStats: DepartmentPosStats;
+}
+
+export interface BasicResponse {
+  status: string;
+  message: string;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthrough": true
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
- Implemented all visualizations for the analysis dashboard.
- Added departments section to display all departments with details.
  - Enabled navigation: /departments -> /departments/{id}.
  - Allows viewing employees within a specific department.
- Added employees section to display all employees with details.
  - Enhanced user experience with seamless navigation and data visualization